### PR TITLE
fix: correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 - [Documentation](https://django-modern-rest.readthedocs.io/en/latest/) - Provides a complete API reference along with practical usage guides.
 - [Source Code](https://github.com/wemake-services/django-modern-rest/) - Is available on GitHub.<!--lint enable double-link-->
-- [Perfomance and Benchmarks](https://django-modern-rest.readthedocs.io/en/latest/pages/deep-dive/performance.html#performance-and-benchmarks) - Performance analysis and benchmark results.
+- [Performance and Benchmarks](https://django-modern-rest.readthedocs.io/en/latest/pages/deep-dive/performance.html#performance-and-benchmarks) - Performance analysis and benchmark results.
 
 ## Extensions
 


### PR DESCRIPTION
Fixed a typo in README.md:
- "Perfomance" → "Performance"

Closes #19